### PR TITLE
Add tags to points

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build Check
 
 on:
   pull_request:

--- a/include/Point.hpp
+++ b/include/Point.hpp
@@ -3,15 +3,33 @@
 
 #include <iostream>
 #include <cmath>
-
+#include <set>
 class Point
 {
 public:
     float x, y, z;
+    std::set<std::string> tags; // Set of tags given to a point cloud
 
-    Point() : x(0), y(0), z(0) {}
+    Point() : x(0), y(0), z(0)
+    {
+        tags.insert("point");
+    }
 
-    Point(float x, float y, float z) : x(x), y(y), z(z) {}
+
+    Point(float x, float y, float z) : x(x), y(y), z(z)
+    {
+        tags.insert("point");
+    }
+
+    bool hasTag(const std::string &tag) const
+    {
+        return tags.find(tag) != tags.end();
+    }
+
+    void removeTag(const std::string &tag)
+    {
+        tags.erase(tag);
+    }
 
     ~Point() {}
 
@@ -23,9 +41,29 @@ public:
     void setY(float y) { this->y = y; }
     void setZ(float z) { this->z = z; }
 
-    void print() const
+    void addTag(const std::string &tag)
     {
-        std::cout << "x: " << x << " y: " << y << " z: " << z << std::endl;
+        tags.insert(tag);
+    }
+
+    const std::set<std::string> &getTags() const
+    {
+        return tags;
+    }
+
+    void print(int mode=0) const
+    {
+        std::cout << x << ", " << y << ", " << z;
+        if (!tags.empty() && mode == 1)
+        {
+            std::cout << " Tags: {";
+            for (const auto &tag : tags)
+            {
+                std::cout << tag << ", ";
+            }
+            std::cout << "\b\b}";
+        }
+        std::cout << std::endl;
     }
 
     float distanceTo(const Point &other) const

--- a/include/PointCloud.hpp
+++ b/include/PointCloud.hpp
@@ -7,11 +7,12 @@
 #include <sstream>
 #include <iostream>
 #include <stdexcept>
-
+#include <unordered_map>
 class PointCloud
 {
 public:
     std::vector<Point> points;
+    std::unordered_map<std::string, std::vector<size_t>>tagMap;
 
     PointCloud() = default;
 
@@ -19,10 +20,18 @@ public:
 
     ~PointCloud() = default;
 
-    void addPoint(const Point &point)
+void addPoint(const Point &point)
+{
+    points.push_back(point);
+
+    // Add the new point's index to the tagMap
+    size_t index = points.size() - 1;
+    const auto &tags = point.getTags();
+    for (const auto &tag : tags)
     {
-        points.push_back(point);
+        tagMap[tag].push_back(index); // Store index instead of pointer
     }
+}
 
     size_t size() const
     {
@@ -47,7 +56,7 @@ public:
     {
         for (const auto &point : points)
         {
-            point.print();
+            point.print(1);
         }
     }
 
@@ -229,6 +238,32 @@ public:
         }
         return croppedCloud;
     }
+
+PointCloud getSubsetByTags(const std::set<std::string> &inputTags) const
+{
+    PointCloud subset;
+
+    for (const auto &tag : inputTags)
+    {
+        auto it = tagMap.find(tag);
+        if (it != tagMap.end())
+        {
+            for (const auto &index : it->second)
+            {
+                if (index < points.size()) // Ensure the index is valid
+                {
+                    subset.addPoint(points[index]);
+                }
+                else
+                {
+                    std::cerr << "Warning: Invalid index in tagMap for tag '" << tag << "'." << std::endl;
+                }
+            }
+        }
+    }
+
+    return subset;
+}
 
     void loadFromPCD(const std::string &filename)
     {

--- a/include/PointCloud.hpp
+++ b/include/PointCloud.hpp
@@ -29,7 +29,7 @@ void addPoint(const Point &point)
     const auto &tags = point.getTags();
     for (const auto &tag : tags)
     {
-        tagMap[tag].push_back(index); // Store index instead of pointer
+        tagMap[tag].push_back(index);
     }
 }
 

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -8,8 +8,8 @@ int PointDemo()
     Point p1(1.0f, 2.0f, 3.0f);
     Point p2(4.0f, 5.0f, 6.0f);
 
-    p1.print();
-    p2.print();
+    p1.print(1);
+    p2.print(0);
 
     std::cout << "Distance between p1 and p2: " << p1.distanceTo(p2) << std::endl;
 
@@ -32,7 +32,12 @@ int PointCloudDemo()
     Point p2(1.0f, 1.1f, 1.4f);
     Point p3(1.0f, 1.2f, 1.3f);
     Point p4(1.0f, 1.3f, 1.2f);
+    p4.addTag("theChoosenOne");
+    p4.addTag("anotherTag");
     Point p5(10.0f, 1.4f, 1.1f); // Outlier point far away from the rest
+    p5.addTag("outlier");
+    Point p6(1.0f, 1.0f, 1.0f);
+    p6.addTag("theChoosenOne");
 
     PointCloud cloud;
     cloud.addPoint(p1);
@@ -40,6 +45,12 @@ int PointCloudDemo()
     cloud.addPoint(p3);
     cloud.addPoint(p4);
     cloud.addPoint(p5);
+    cloud.addPoint(p6);
+
+    std::set<std::string> filterTags = {"theChoosenOne"};
+    PointCloud filteredCloud = cloud.getSubsetByTags(filterTags);
+    std::cout<< "the points with tag theChoosenOne are: ";
+    filteredCloud.print();
 
     std::cout << "Points in the PointCloud (before SOR filter):" << std::endl;
     cloud.print();
@@ -67,11 +78,10 @@ int fileIODemo()
 
     PointCloud cloud;
     cloud.loadFromPCD("/home/nisarg/light_clouds/files/lamppost.pcd");
-    cloud.print();
+    std::cout << "Input cloud has: "<< cloud.size() << "number of points" << std::endl;
     std::cout << "Centroid: ";
     cloud.calculateCentroid().print();
     cloud.dumpToPCD("/home/nisarg/light_clouds/files/output.pcd");
-
     return 0;
 }
 


### PR DESCRIPTION
Add ability to add tags to points and query the points with certain tags in the point cloud.

example:
```
    Point p1(1.0f, 1.0f, 1.0f);
    Point p2(1.0f, 1.1f, 1.4f);
    Point p3(1.0f, 1.2f, 1.3f);
    p3.addTag("corner");
    Point p4(1.0f, 1.3f, 1.2f);
    p4.addTag("corner");
    
    PointCloud cloud;
    cloud.addPoint(p1);
    cloud.addPoint(p2);
    cloud.addPoint(p3);
    cloud.addPoint(p4);
    
    std::set<std::string> filterTags = {"corner"};
    PointCloud filteredCloud = cloud.getSubsetByTags(filterTags);
    std::cout<< "the points with the tag corner are: ";
    filteredCloud.print();
```